### PR TITLE
Add support for GET_CONFIG i3ipc message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ mesonbuild-test
 __pycache__
 env
 *.pyc
+build

--- a/i3ipc-glib/i3ipc-connection.c
+++ b/i3ipc-glib/i3ipc-connection.c
@@ -1521,6 +1521,32 @@ i3ipcVersionReply *i3ipc_connection_get_version(i3ipcConnection *self, GError **
 }
 
 /**
+ * i3ipc_connection_get_config:
+ * @self: An #i3ipcConnection
+ * @err: (allow-none): return location for a GError, or NULL
+ *
+ * Gets the config of i3. 
+ *
+ * Returns: (transfer full): an *gchar
+ */
+gchar *i3ipc_connection_get_config(i3ipcConnection *self, GError **err) {
+    gchar *reply;
+    GError *tmp_error = NULL;
+
+    g_return_val_if_fail(err == NULL || *err == NULL, NULL);
+
+    reply = i3ipc_connection_message(self, I3IPC_MESSAGE_TYPE_GET_CONFIG, "", &tmp_error);
+
+    if (tmp_error != NULL) {
+        g_free(reply);
+        g_propagate_error(err, tmp_error);
+        return NULL;
+    }
+
+    return reply;
+}
+
+/**
  * i3ipc_connection_main:
  * @self: An #i3ipcConnection
  *

--- a/i3ipc-glib/i3ipc-connection.h
+++ b/i3ipc-glib/i3ipc-connection.h
@@ -64,6 +64,8 @@ typedef struct _i3ipcConnectionPrivate i3ipcConnectionPrivate;
  * @I3IPC_MESSAGE_TYPE_GET_MARKS:
  * @I3IPC_MESSAGE_TYPE_GET_BAR_CONFIG:
  * @I3IPC_MESSAGE_TYPE_GET_VERSION:
+ * @I3IPC_MESSAGE_TYPE_GET_BINDING_MODES:
+ * @I3IPC_MESSAGE_TYPE_GET_CONFIG:
  *
  * Message type enumeration for #i3ipcConnection
  *
@@ -78,6 +80,8 @@ typedef enum { /*< underscore_name=i3ipc_message_type >*/
                I3IPC_MESSAGE_TYPE_GET_MARKS,
                I3IPC_MESSAGE_TYPE_GET_BAR_CONFIG,
                I3IPC_MESSAGE_TYPE_GET_VERSION,
+               I3IPC_MESSAGE_TYPE_GET_BINDING_MODES,
+               I3IPC_MESSAGE_TYPE_GET_CONFIG,
 } i3ipcMessageType;
 
 struct _i3ipcConnection {
@@ -124,6 +128,8 @@ i3ipcBarConfigReply *i3ipc_connection_get_bar_config(i3ipcConnection *self, cons
                                                      GError **err);
 
 i3ipcVersionReply *i3ipc_connection_get_version(i3ipcConnection *self, GError **err);
+
+gchar *i3ipc_connection_get_config(i3ipcConnection *self, GError **err);
 
 void i3ipc_connection_main(i3ipcConnection *self);
 


### PR DESCRIPTION
Hello, this PR adds the ability to use the GET_CONFIG message as is available via `i3-msg -t GET_CONFIG`.  I have tested it w/ a Vala program and it's working as expected.  I'm happy to do any extra work if I've missed something...