### PR TITLE
Use I3SOCK environment variable if socket_path is null

### DIFF
--- a/i3ipc-glib/i3ipc-connection.c
+++ b/i3ipc-glib/i3ipc-connection.c
@@ -321,9 +321,14 @@ static void i3ipc_connection_init(i3ipcConnection *self) {
 i3ipcConnection *i3ipc_connection_new(const gchar *socket_path, GError **err) {
     i3ipcConnection *conn;
     GError *tmp_error = NULL;
+    gchar *sock = g_strdup(socket_path);
+
+    if (!sock) {
+	    sock = getenv("I3SOCK");
+    }
 
     conn =
-        g_initable_new(I3IPC_TYPE_CONNECTION, NULL, &tmp_error, "socket-path", socket_path, NULL);
+        g_initable_new(I3IPC_TYPE_CONNECTION, NULL, &tmp_error, "socket-path", sock, NULL);
 
     if (tmp_error != NULL) {
         g_propagate_error(err, tmp_error);


### PR DESCRIPTION
The example programs were segfaulting for me, because i3ipc_connection_new would return NULL when a NULL socket_path was specified. Since multiple examples pass NULL, and [the documentation suggests](https://dubstepdish.com/i3ipc-glib/i3ipcConnection.html#i3ipc-connection-new) NULL is allowed for the socket_path, it seems like the expected behavior is that a valid connection should be returned if possible, even if socket_path is NULL.

I did not test this with i3, but I did test this with sway and it seems to work as expected.