### PR TITLE
Make gobject-introspection actually optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,15 @@ AC_SUBST(I3IPC_MINOR_VERSION)
 AC_SUBST(I3IPC_MICRO_VERSION)
 AC_SUBST(I3IPC_VERSION)
 
-GOBJECT_INTROSPECTION_CHECK([1.32.0])
+have_introspection=false
+m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [
+    GOBJECT_INTROSPECTION_CHECK([1.32.0])
+    if test "x$found_introspection" = xyes; then
+        have_introspection=true
+    fi
+], [
+    AM_CONDITIONAL([HAVE_INTROSPECTION], false)
+])
 
 # Check for gtk-doc
 GTK_DOC_CHECK([1.14],[--flavour no-tmpl])


### PR DESCRIPTION
in the readme it says that gobject-introspection is optional, however
without this change the configure would fail with

`HAVE_INTROSPECTION does not appear in AM_CONDITIONAL`

after this change, configuring without gobject-introspection works as it
should

tested by changing the source of the nixpkgs i3ipc-glib drv to point to
my local checkout with this change applied

verified that `share/gir-1.0/i3ipc-1.0.gir-1` exists

copied from https://github.com/harfbuzz/harfbuzz/blob/63bc6be0cf7151dfbd7a004f5b644e802c2ff6ca/configure.ac#L173-L186


would close https://github.com/altdesktop/i3ipc-glib/issues/36 and https://github.com/altdesktop/i3ipc-glib/issues/31 if they were open